### PR TITLE
ユーザー登録処理の実装

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -65,8 +65,8 @@ class RegisterController extends Controller
             'name' => ['required', 'string', 'max:255'],
             'email' => ['required', 'string', 'email', 'max:255', 'unique:users'],
             'password' => ['required', 'string', 'min:8', 'confirmed'],
-            'department' => ['required'],
-            'grade' => ['required']
+            'department' => ['required', 'exists:departments,id'],
+            'grade' => ['required', 'exists:grades,id'],
         ]);
     }
 

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -3,6 +3,8 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Models\Department;
+use App\Models\Grade;
 use App\Models\User;
 use Illuminate\Foundation\Auth\RegistersUsers;
 use Illuminate\Support\Facades\Hash;
@@ -38,6 +40,17 @@ class RegisterController extends Controller
     public function __construct()
     {
         $this->middleware('guest');
+    }
+
+    public function showRegistrationForm()
+    {
+        // 学科を取得
+        $departments = Department::all();
+        // 学年を取得
+        $grades = Grade::all();
+
+        // viewに学科、学年を渡す
+        return view('auth.register', compact('departments', 'grades'));
     }
 
     /**

--- a/app/Models/Department.php
+++ b/app/Models/Department.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Department extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/Grade.php
+++ b/app/Models/Grade.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Grade extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -21,6 +21,8 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
+        'department_id',
+        'grade_id',
     ];
 
     /**

--- a/database/migrations/2014_10_12_000000_create_users_table.php
+++ b/database/migrations/2014_10_12_000000_create_users_table.php
@@ -22,8 +22,8 @@ return new class extends Migration
             $table->string('email')->unique();
             $table->timestamp('email_verified_at')->nullable();
             $table->string('password');
-            $table->boolean('master');
-            $table->boolean('delete');
+            $table->boolean('master')->default(false);
+            $table->boolean('delete')->default(false);
             $table->rememberToken();
             $table->timestamps();
         });

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -11,8 +11,9 @@
                     <form method="POST" action="{{ route('register') }}">
                         @csrf
 
+                        <!-- 名前 -->
                         <div class="row mb-3">
-                            <label for="name" class="col-md-4 col-form-label text-md-end">{{ __('Name') }}</label>
+                            <label for="name" class="col-md-4 col-form-label text-md-end">{{ __('名前') }}</label>
 
                             <div class="col-md-6">
                                 <input id="name" type="text" class="form-control @error('name') is-invalid @enderror" name="name" value="{{ old('name') }}" required autocomplete="name" autofocus>
@@ -25,8 +26,39 @@
                             </div>
                         </div>
 
+                        <!-- 学科 -->
                         <div class="row mb-3">
-                            <label for="email" class="col-md-4 col-form-label text-md-end">{{ __('Email Address') }}</label>
+                            <label for="department" class="col-md-4 col-form-label text-md-end">{{ __('学科') }}</label>
+
+                            <div class="col-md-6">
+                                <input id="department" type="text" class="form-control @error('department') is-invalid @enderror" name="department" value="{{ old('department') }}" required autocomplete="department" autofocus>
+
+                                @error('department')
+                                    <span class="invalid-feedback" role="alert">
+                                        <strong>{{ $message }}</strong>
+                                    </span>
+                                @enderror
+                            </div>
+                        </div>
+
+                        <!-- 学年 -->
+                        <div class="row mb-3">
+                            <label for="grade" class="col-md-4 col-form-label text-md-end">{{ __('学年') }}</label>
+
+                            <div class="col-md-6">
+                                <input id="grade" type="text" class="form-control @error('grade') is-invalid @enderror" name="grade" value="{{ old('grade') }}" required autocomplete="grade" autofocus>
+
+                                @error('grade')
+                                    <span class="invalid-feedback" role="alert">
+                                        <strong>{{ $message }}</strong>
+                                    </span>
+                                @enderror
+                            </div>
+                        </div>
+
+                        <!-- メールアドレス -->
+                        <div class="row mb-3">
+                            <label for="email" class="col-md-4 col-form-label text-md-end">{{ __('メールアドレス') }}</label>
 
                             <div class="col-md-6">
                                 <input id="email" type="email" class="form-control @error('email') is-invalid @enderror" name="email" value="{{ old('email') }}" required autocomplete="email">
@@ -39,8 +71,9 @@
                             </div>
                         </div>
 
+                        <!-- パスワード -->
                         <div class="row mb-3">
-                            <label for="password" class="col-md-4 col-form-label text-md-end">{{ __('Password') }}</label>
+                            <label for="password" class="col-md-4 col-form-label text-md-end">{{ __('パスワード') }}</label>
 
                             <div class="col-md-6">
                                 <input id="password" type="password" class="form-control @error('password') is-invalid @enderror" name="password" required autocomplete="new-password">
@@ -53,14 +86,16 @@
                             </div>
                         </div>
 
+                        <!-- 確認用パスワード -->
                         <div class="row mb-3">
-                            <label for="password-confirm" class="col-md-4 col-form-label text-md-end">{{ __('Confirm Password') }}</label>
+                            <label for="password-confirm" class="col-md-4 col-form-label text-md-end">{{ __('確認パスワード') }}</label>
 
                             <div class="col-md-6">
                                 <input id="password-confirm" type="password" class="form-control" name="password_confirmation" required autocomplete="new-password">
                             </div>
                         </div>
 
+                        <!-- 登録ボタン -->
                         <div class="row mb-0">
                             <div class="col-md-6 offset-md-4">
                                 <button type="submit" class="btn btn-primary">

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -31,7 +31,12 @@
                             <label for="department" class="col-md-4 col-form-label text-md-end">{{ __('学科') }}</label>
 
                             <div class="col-md-6">
-                                <input id="department" type="text" class="form-control @error('department') is-invalid @enderror" name="department" value="{{ old('department') }}" required autocomplete="department" autofocus>
+                                <select id="department" class="form-control @error('department') is-invalid @enderror" name="department" value="{{ old('department') }}" required autocomplete="department" autofocus>
+                                    <option value="" disabled>選択してください</option>
+                                    @foreach($departments as $department)
+                                    <option value="{{ $department->id }}">{{ $department->name }}</option>
+                                    @endforeach
+                                </select>
 
                                 @error('department')
                                     <span class="invalid-feedback" role="alert">
@@ -46,8 +51,13 @@
                             <label for="grade" class="col-md-4 col-form-label text-md-end">{{ __('学年') }}</label>
 
                             <div class="col-md-6">
-                                <input id="grade" type="text" class="form-control @error('grade') is-invalid @enderror" name="grade" value="{{ old('grade') }}" required autocomplete="grade" autofocus>
+                                <select id="grade" type="text" class="form-control @error('grade') is-invalid @enderror" name="grade" value="{{ old('grade') }}" required autocomplete="grade" autofocus>
+                                    <option value="" disabled>選択してください</option>
+                                    @foreach($grades as $grade)
+                                    <option value="{{ $grade->id }}">{{ $grade->name }}</option>
+                                    @endforeach
 
+                                </select>
                                 @error('grade')
                                     <span class="invalid-feedback" role="alert">
                                         <strong>{{ $message }}</strong>


### PR DESCRIPTION
- Userのマイグレーション・モデルに学科、学年を追加
- RegisterControllerにviewに渡す学科・学年を渡す処理を追加
- RegisterControllerに学科・学年を登録する処理を追加
- viewに学科・学年のプルダウンを追加
- usersテーブルのmaster(管理者フラグ)とdelte(削除フラグ)にデフォルト値を追加