### PR TITLE
ユーザー側の科目登録機能の実装

### DIFF
--- a/app/Http/Controllers/SubjectController.php
+++ b/app/Http/Controllers/SubjectController.php
@@ -4,6 +4,8 @@ namespace App\Http\Controllers;
 
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
+use App\Models\EnrolledSubject;
+use Illuminate\Support\Facades\Auth;
 
 class SubjectController extends Controller
 {
@@ -18,7 +20,18 @@ class SubjectController extends Controller
     }
 
     //ユーザーの科目登録確認ページ
-    public function user_subject_register_confirm() {
-        return view('user.user_subject_register_confirm');
+    public function user_subject_register_confirm(Request $request) {
+        if (!Auth::check()) {
+            // ログインしていない場合はログインページに遷移
+            return redirect('/login');
+        } else {
+            $form = $request->all();
+            unset($form['_token']);
+            // セッションに入力された科目を登録する
+            session()->put('subjects', $request->subjects);
+            // 科目をビューに渡し、リダイレクト
+            $subjects = $request->subjects;
+            return view('user.user_subject_register_confirm', compact('subjects'));
+        }
     }
 }

--- a/app/Http/Controllers/SubjectController.php
+++ b/app/Http/Controllers/SubjectController.php
@@ -39,8 +39,11 @@ class SubjectController extends Controller
             unset($form['_token']);
             // セッションに入力された科目を登録する
             session()->put('subjects', $request->subjects);
-            // viewに科目を渡し、リダイレクト
-            $subjects = $request->subjects;
+            // 選択科目のidを受け取る
+            $subjects_id = $request->subjects;
+            // 選択した科目の情報を入れる配列の定義
+            $subjects = Subject::whereIn('id', $subjects_id)->get();
+
             return view('user.user_subject_register_confirm', compact('subjects'));
         }
     }

--- a/app/Http/Controllers/SubjectController.php
+++ b/app/Http/Controllers/SubjectController.php
@@ -47,4 +47,28 @@ class SubjectController extends Controller
             return view('user.user_subject_register_confirm', compact('subjects'));
         }
     }
+
+    public function user_subject_create(Request $request) {
+        // ログインしていない場合はログインページに遷移
+        if (!Auth::check()) {
+            return redirect('/login');
+        } else {
+            // セッションから科目idの配列を取得
+            $subjects_id = session('subjects');
+            // 科目idから一致する科目を全件取得
+            $subjects = Subject::whereIn('id', $subjects_id)->get();
+            // 1科目ずつ登録
+            foreach ($subjects as $subject) {
+                // 各情報を埋め込む
+                $enrollSubject = new EnrolledSubject();
+                $enrollSubject->subject_id = $subject->id;
+                $enrollSubject->student_id = Auth::id();
+                // DBへ登録
+                $enrollSubject->save();
+            }
+            // セッションを削除
+            session()->forget('subjects');
+            return redirect('/user/user_top');
+        }
+    }
 }

--- a/app/Http/Controllers/SubjectController.php
+++ b/app/Http/Controllers/SubjectController.php
@@ -5,7 +5,9 @@ namespace App\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use App\Models\EnrolledSubject;
+use App\Models\Subject;
 use Illuminate\Support\Facades\Auth;
+use Mockery\Matcher\Subset;
 
 class SubjectController extends Controller
 {
@@ -16,7 +18,15 @@ class SubjectController extends Controller
 
     //ユーザーの科目登録ページ
     public function user_subject_register() {
-        return view('user.user_subject_register');
+        if (!Auth::check()) {
+            // ログインしていない場合はログインページに遷移
+            return redirect('/login');
+        } else {
+            // 削除フラグがfalseの科目のみを取得する
+            $subjects = Subject::where('is_deleted', 0)->with(['user:id,name'])->get();
+            // viewに科目を渡し、リダイレクト
+            return view('user.user_subject_register', compact('subjects'));
+        }
     }
 
     //ユーザーの科目登録確認ページ
@@ -29,7 +39,7 @@ class SubjectController extends Controller
             unset($form['_token']);
             // セッションに入力された科目を登録する
             session()->put('subjects', $request->subjects);
-            // 科目をビューに渡し、リダイレクト
+            // viewに科目を渡し、リダイレクト
             $subjects = $request->subjects;
             return view('user.user_subject_register_confirm', compact('subjects'));
         }

--- a/app/Models/EnrolledSubject.php
+++ b/app/Models/EnrolledSubject.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class EnrolledSubject extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/Subject.php
+++ b/app/Models/Subject.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Subject extends Model
+{
+    use HasFactory;
+}

--- a/app/Models/Subject.php
+++ b/app/Models/Subject.php
@@ -4,8 +4,15 @@ namespace App\Models;
 
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use App\Models\User;
 
 class Subject extends Model
 {
     use HasFactory;
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'teacher_id', 'id');
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,9 +4,12 @@ namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
+use App\Models\Subject;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 
 class User extends Authenticatable
 {
@@ -44,4 +47,9 @@ class User extends Authenticatable
         'email_verified_at' => 'datetime',
         'password' => 'hashed',
     ];
+
+    public function subjects(): HasMany
+    {
+        return $this->hasMany(Subject::class);
+    }
 }

--- a/database/migrations/2025_04_08_010947_create__enrolled_subjects_table.php
+++ b/database/migrations/2025_04_08_010947_create__enrolled_subjects_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('enrolled_subjects', function (Blueprint $table) {
             $table->id();
-            $table->foreignId('subject_id')->constrained(); // 科目ID
+            $table->foreignId('subject_id')->constrained('subjects'); // 科目ID
             $table->foreignId('student_id')->constrained('users'); // 生徒のアカウントID
             $table->boolean('is_deleted')->default(false); 
             $table->timestamps();

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -24,7 +24,8 @@ class DatabaseSeeder extends Seeder
         $this->call(PeriodsSeeder::class);
         $this->call(DepartmentsSeeder::class);
         $this->call(AttendanceStatusSeeder::class);
-            // 他のシーダーがあればここに追加
-
+        $this->call(UsersSeeder::class);
+        $this->call(SubjectSeeder::class);
+        // 他のシーダーがあればここに追加
     }
 }

--- a/database/seeders/SubjectSeeder.php
+++ b/database/seeders/SubjectSeeder.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Database\Seeders;
+
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\DB;
+
+class SubjectSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Subjectデータを定義
+        $subjects = [
+            [
+                'name' => 'Java基礎A',
+                'teacher_id' => 3,
+                'total_lectures' => 30,
+                'is_deleted' => 0,
+                'term' => 1,
+            ],
+            [
+                'name' => 'Python基礎',
+                'teacher_id' => 3,
+                'total_lectures' => 30,
+                'is_deleted' => 0,
+                'term' => 1,
+            ],
+            [
+                'name' => 'Java応用A',
+                'teacher_id' => 4,
+                'total_lectures' => 30,
+                'is_deleted' => 0,
+                'term' => 2,
+            ],
+        ];
+
+        DB::table('subjects')->insert($subjects);
+    }
+}

--- a/database/seeders/UsersSeeder.php
+++ b/database/seeders/UsersSeeder.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Database\Seeders;
+
+use Carbon\Carbon;
+use Illuminate\Database\Console\Seeds\WithoutModelEvents;
+use Illuminate\Database\Seeder;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\DB;
+
+class UsersSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        // Userデータの定義
+        $users = [
+            [
+                'name' => '鈴木太郎',
+                'department_id' => 1,
+                'grade_id' => 1,
+                'email'  => 'suzuki@morijyobi.ac.jp',
+                // 'email_varified_at' => null,
+                'password' => Hash::make('morijyobi'),
+                'master' => 0,
+                'delete' => 0,
+                'remember_token' => null,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
+            [
+                'name' => '藤村大樹',
+                'department_id' => 3,
+                'grade_id' => 3,
+                'email'  => 'hujimura@morijyobi.ac.jp',
+                // 'email_varified_at' => null,
+                'password' => Hash::make('morijyobi'),
+                'master' => 0,
+                'delete' => 0,
+                'remember_token' => null,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
+            [
+                'name' => '山口賢治',
+                'department_id' => 3,
+                'grade_id' => 3,
+                'email'  => 'yamaguchi@morijyobi.ac.jp',
+                // 'email_varified_at' => null,
+                'password' => Hash::make('morijyobi'),
+                'master' => 1,
+                'delete' => 0,
+                'remember_token' => null,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
+            [
+                'name' => '原田又三郎',
+                'department_id' => 2,
+                'grade_id' => 2,
+                'email'  => 'harada@morijyobi.ac.jp',
+                // 'email_varified_at' => null,
+                'password' => Hash::make('morijyobi'),
+                'master' => 1,
+                'delete' => 0,
+                'remember_token' => null,
+                'created_at' => Carbon::now(),
+                'updated_at' => Carbon::now(),
+            ],
+        ];
+
+        DB::table('users')->insert($users);
+    }
+}

--- a/resources/views/user/user_subject_register.blade.php
+++ b/resources/views/user/user_subject_register.blade.php
@@ -7,5 +7,17 @@
 </head>
 <body>
   <h1>ユーザーの科目登録画面</h1>
+  <form action="/user_subject_register_confirm" method="post" enctype="multipart/form-data">
+    @csrf
+    <div>
+      @foreach($subjects as $subject)
+      <div>
+        <input type="checkbox" name="subjects[]" value="{{ $subject->id }}" id="{{ $subject->id }}">
+        <label for="{{ $subject->id }}">{{ $subject->name }} - {{ $subject->term }} - {{ $subject->user->name }}</label>
+      </div>
+      @endforeach
+    </div>
+    <button type="submit">登録</button>
+  </form>
 </body>
 </html>

--- a/resources/views/user/user_subject_register.blade.php
+++ b/resources/views/user/user_subject_register.blade.php
@@ -17,7 +17,7 @@
       </div>
       @endforeach
     </div>
-    <button type="submit">登録</button>
+    <button type="submit">確認</button>
   </form>
 </body>
 </html>

--- a/resources/views/user/user_subject_register_confirm.blade.php
+++ b/resources/views/user/user_subject_register_confirm.blade.php
@@ -7,5 +7,13 @@
 </head>
 <body>
   <h1>ユーザーの科目登録確認画面</h1>
+  <form action="/user_subject_create" method="post" enctype="multipart/form-data">
+    @csrf
+    <p>科目名-期間</p>
+    @foreach ($subjects as $subject)
+    <p>{{ $subject->name }} - {{ $subject->term }}</p>
+    @endforeach
+    <button type="submit">登録</button>
+  </form>
 </body>
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -38,6 +38,8 @@ Route::get('/admin_subject_register', [SubjectController::class, 'admin_subject_
 Route::get('/user_subject_register', [SubjectController::class, 'user_subject_register']);
 //ユーザーの科目登録確認ページのルーティング
 Route::get('/user_subject_register_confirm', [SubjectController::class, 'user_subject_register_confirm']);
+// ユーザーの科目登録処理(DBへ登録)へのルーティング
+Route::get('/user_subject_create', [SubjectController::class, 'user_subject_create']);
 Route::get('/home', [App\Http\Controllers\HomeController::class, 'user_top'])->name('home');
 
 // 利用者のトップ画面

--- a/routes/web.php
+++ b/routes/web.php
@@ -37,10 +37,10 @@ Route::get('/admin_subject_register', [SubjectController::class, 'admin_subject_
 //ユーザーの科目登録ページのルーティング
 Route::get('/user_subject_register', [SubjectController::class, 'user_subject_register']);
 //ユーザーの科目登録確認ページのルーティング
-Route::get('/user_subject_register_confirm', [SubjectController::class, 'user_subject_register_confirm']);
+Route::post('/user_subject_register_confirm', [SubjectController::class, 'user_subject_register_confirm']);
 // ユーザーの科目登録処理(DBへ登録)へのルーティング
-Route::get('/user_subject_create', [SubjectController::class, 'user_subject_create']);
-Route::get('/home', [App\Http\Controllers\HomeController::class, 'user_top'])->name('home');
+Route::post('/user_subject_create', [SubjectController::class, 'user_subject_create']);
+// Route::get('/home', [App\Http\Controllers\HomeController::class, 'user_top'])->name('home');
 
 // 利用者のトップ画面
 Route::get('user/user_top',[UserAttendanceController::class,'index']);


### PR DESCRIPTION
# SubjectController
- 科目登録・確認画面に科目データを送る処理を追記
- 履修科目テーブルに科目を追加する処理を実装
# view
- フォームの設置
- 科目データを一覧で表示
# web.php
- 履修科目登録処理へのルーティングを追記
# model
- userとsubjectのモデルを追加
# seeder
- userとsubjectのseederを追加