### PR TITLE
ユーザー科目登録確認の実装/ユーザーアカウント登録の修正

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -30,7 +30,7 @@ class RegisterController extends Controller
      *
      * @var string
      */
-    protected $redirectTo = '/home';
+    protected $redirectTo = '/user';
 
     /**
      * Create a new controller instance.

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -45,9 +45,9 @@ class RegisterController extends Controller
     public function showRegistrationForm()
     {
         // 学科を取得
-        $departments = Department::all();
+        $departments = Department::where('id', '!=', 99)->get();
         // 学年を取得
-        $grades = Grade::all();
+        $grades = Grade::where('id', '!=', 99)->get();
 
         // viewに学科、学年を渡す
         return view('auth.register', compact('departments', 'grades'));

--- a/app/Http/Controllers/SubjectController.php
+++ b/app/Http/Controllers/SubjectController.php
@@ -105,6 +105,7 @@ class SubjectController extends Controller
         } else {
             // 削除フラグがfalseの科目のみを取得する
             $subjects = Subject::where('is_deleted', 0)->with(['user:id,name'])->get();
+            // dd($subjects);
             // viewに科目を渡し、リダイレクト
             return view('user.user_subject_register', compact('subjects'));
         }
@@ -149,7 +150,7 @@ class SubjectController extends Controller
             }
             // セッションを削除
             session()->forget('subjects');
-            return redirect('/user/user_top');
+            return redirect('/user');
         }
     }
 

--- a/public/css/U_subject_register.css
+++ b/public/css/U_subject_register.css
@@ -54,11 +54,11 @@ table th:nth-child(1) {
 }
 
 table th:nth-child(2) {
-    width: 30%;
+    width: 40%;
 }
 
 table th:nth-child(3) {
-    width: 30%;
+    width: 20%;
 }
 
 table th:nth-child(4) {

--- a/public/css/U_subject_register_confirm.css
+++ b/public/css/U_subject_register_confirm.css
@@ -1,0 +1,92 @@
+@charset "UTF-8";
+
+* {
+    margin: 0;
+    padding: 0;
+}
+
+#U_subject_confirm {
+    #subjects {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        width: 40%;
+        margin: 0 auto;
+    }
+
+    .container {
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        margin: 80px auto 40px;
+        border: 2px solid #000;
+        padding: 32px 60px;
+    }
+    
+    .head {
+        color: black;
+        text-align: center;
+        font-size: 32px;
+        font-weight: 500;
+    }
+
+    table {
+        margin-top: 32px;
+        width: 100%;
+        border-collapse: collapse;
+
+    }
+
+    th, td {
+        padding-left: 20px;
+    }
+
+    th:nth-child(2), td:nth-child(2) {
+        text-align: center;
+        padding: 0;
+    }
+
+    th :nth-child(1) {
+        width: 85%;
+    }
+
+    th :nth-child(2) {
+        width: 15%;
+    }
+
+    th, td {
+        height: 32px;
+        border-top: #000 1px solid;
+        border-bottom: #000 1px solid;
+    }
+
+    .btns {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+
+        button {
+            width: 200px;
+            height: 40px;
+            border-radius: 8px;
+            border: none;
+            color: #ffffff;
+        }
+
+        button:nth-child(1) {
+            background-color: #DD4F4F;
+        }
+
+        button:nth-child(1):hover {
+            background-color: #ba4141;
+        }
+
+        button:nth-child(2) {
+            background-color: #4FDD59;
+        }
+
+        button:nth-child(2):hover {
+            background-color: #42b149;
+        }
+    }
+}

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -4,38 +4,41 @@
 <link rel="stylesheet" href="{{ asset('css/U_register-style.css') }}">
 <div id="container">
     <h3>学生情報の登録</h3>
-    <p id="grade">学年</p>
-    <select id="gradeInput" type="text" name="grade" value="{{ old('grade') }}" required autocomplete="grade" autofocus>
-        @foreach($grades as $grade)
+    <form action="{{ route('register') }}" method="POST" enctype="multipart/form-data">
+        @csrf
+        <p id="grade">学年</p>
+        <select id="gradeInput" type="text" name="grade" value="{{ old('grade') }}" required autocomplete="grade" autofocus>
+            @foreach($grades as $grade)
             <option value="{{ $grade->id }}">{{ $grade->name }}</option>
-        @endforeach
-    </select>
+            @endforeach
+        </select>
 
-    <p id="course">学科</p>
-    <select id="courseInput" name="department" value="{{ old('department') }}" required autocomplete="department" autofocus>
-        @foreach($departments as $department)
+        <p id="course">学科</p>
+        <select id="courseInput" name="department" value="{{ old('department') }}" required autocomplete="department" autofocus>
+            @foreach($departments as $department)
             <option value="{{ $department->id }}">{{ $department->name }}</option>
-        @endforeach
-    </select>
+            @endforeach
+        </select>
 
-    <p id="name">名前</p>
-    <input id="nameInput" name="name" type="text">
+        <p id="name">名前</p>
+        <input id="nameInput" name="name" type="text">
 
-    <p id="mail">メールアドレス</p>
-    <input id="mailInput" name="email" type="text">
+        <p id="mail">メールアドレス</p>
+        <input id="mailInput" name="email" type="text">
 
-    <p id="pw">パスワード</p>
-    <input id="pwInput" name="password" type="password">
+        <p id="pw">パスワード</p>
+        <input id="pwInput" name="password" type="password">
 
-    <p id="pwConfirm" name="password_confirmation">パスワード(確認)</p>
-    <input id="pwConfirmInput" type="password">
+        <p id="pwConfirm">パスワード(確認)</p>
+        <input id="pwConfirmInput" type="password" name="password_confirmation">
 
-    <!-- 未入力時に警告 -->
-    <div id="redAlert"></div>
-    <div id="pwAlert"></div>
+        <!-- 未入力時に警告 -->
+        <div id="redAlert"></div>
+        <div id="pwAlert"></div>
 
-    <button type="button" id="registerBtn" class="registerBtn">登録</button>
-  </div>
-<script src="{{ asset('js/U_register.js') }}"></script>
+        <button type="submit" id="registerBtn" class="registerBtn">登録</button>
+    </form>
+</div>
+<!-- <script src="{{ asset('js/U_register.js') }}"></script> -->
 
 @endsection

--- a/resources/views/user/user_subject_register_confirm.blade.php
+++ b/resources/views/user/user_subject_register_confirm.blade.php
@@ -3,18 +3,33 @@
 @section('content')
 <link rel="stylesheet" href="{{ asset('css/U_subject_register_confirm.css') }}">
 
-<body>
-  <h1>ユーザーの科目登録確認画面</h1>
-  <form action="/user_subject_create" method="post" enctype="multipart/form-data">
-    @csrf
-    <p>科目名-期間</p>
-    @foreach ($subjects as $subject)
-    <p>{{ $subject->name }} - {{ $subject->term }}</p>
-    @endforeach
-    <button type="submit">登録</button>
+<body id="U_subject_confirm">
+
+  <form action="/user_subject_create" method="post" enctype="multipart/form-data" id="subjects">
+    <div class="container">
+      <h1 class="head">登録確認</h1>
+      @csrf
+      <table>
+        <tr>
+          <th>科目名</th>
+          <th>期間</th>
+        </tr>
+        @foreach ($subjects as $subject)
+        <tr>
+          <td>{{ $subject->name }}</td>
+          <td>{{ $subject->term }}</td>
+        </tr>
+        @endforeach
+      </table>
+    </div>
+    <div class="btns">
+      <button type="button" onclick="history.back()">戻る</button>
+      <button type="submit">登録</button>
+    </div>
   </form>
-  
+
   <script src="{{ asset('js/U_subject_register.js') }}" defer></script>
 </body>
+
 </html>
 @endsection


### PR DESCRIPTION
- ユーザーの科目登録確認のCSS適用
- 登録完了後のリダイレクト先をユーザーTOPに修正
- ユーザーアカウント登録の際、学年・学科に先生用のデータが入らないよう修正
- formタグの追加
- inputのnameを修正
- buttonのtypeをsubmitに修正
- 登録完了後のリダイレクト先を変更